### PR TITLE
chore(same-line): changes jsxBracketSameLine setting

### DIFF
--- a/index.json
+++ b/index.json
@@ -3,6 +3,6 @@
   "singleQuote": true,
   "trailingComma": "all",
   "semi": false,
-  "jsxBracketSameLine": true,
+  "bracketSameLine": true,
   "arrowParens": "always"
 }


### PR DESCRIPTION
## Description
The `jsxBracketSameLine` setting is [outdated](https://prettier.io/blog/2021/09/09/2.4.0.html#replace-jsxbracketsameline-option-with-bracketsameline-option-11006httpsgithubcomprettierprettierpull11006-by-kurtztechhttpsgithubcomkurtztech) and produces a console warning.
The newer setting is `bracketSameLine`.

### Dependencies
N/A